### PR TITLE
feat: Make it possible to configure "Globals" and "Profiles" directly from within the values.yaml

### DIFF
--- a/charts/zaakbrug/Chart.yaml
+++ b/charts/zaakbrug/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.0.4
 description: Install ZaakBrug (zds-to-zgw) on Haven, powerd by the Frank!Framework
 name: zaakbrug
 type: application
-version: 0.2.1
+version: 0.2.2
 
 home: https://github.com/ibissource/zaakbrug
 icon: "https://raw.githubusercontent.com/ibissource/zaakbrug/master/zaakbrug-icon.png"

--- a/charts/zaakbrug/README.md
+++ b/charts/zaakbrug/README.md
@@ -16,15 +16,15 @@ These values are:
 
 For the ZaakBrug to work correctly some values need to be verified and other have to be filled in. 
 
-Check if all the zgw.endpoints are configured right. Add a configMap to both zgw.globalsConfigMap and zgs.profilesConfigMap
+Check if all the zaakbrug.zgw.endpoints are configured right. Add a configMap to both zaakbrug.zgw.globalsConfigMap and zaakbrug.zgs.profilesConfigMap
 
 #### Globals and Profiles
 
-The Globals.json should contain organizations and role mappings. 
+The Globals should contain organizations and role mappings. 
 
-The Profiles.json contains information about zaakTypes. The reason this file is separate, is to make it more sharable with other gemeentes. 
+The Profiles contain information about zaakTypes. The reason this file is separate, is to make it more sharable with other gemeentes.
 
-These files need to be added to the namespace as a configMap. The name of the configMap and the key of the data should be added in the values.yaml under .name and .subPath.
+The data should be entered as yaml inside the values.yaml at zaakbrug.globals and zaakbrug.profiles. The JSON files will be created by the Helm Chart. 
 
 ### Credentials
 

--- a/charts/zaakbrug/templates/configmap.yaml
+++ b/charts/zaakbrug/templates/configmap.yaml
@@ -182,3 +182,25 @@ data:
         {{- end }}
       {{- end }}
     </Context>
+---
+{{- if .Values.zaakbrug.globals }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "zaakbrug.fullname" . }}-globals
+  labels:
+    {{- include "zaakbrug.labels" . | nindent 4 }}
+data:
+  Globals.json: {{ .Values.zaakbrug.globals | toJson | quote }}
+{{- end }}
+---
+{{- if .Values.zaakbrug.profiles }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "zaakbrug.fullname" . }}-profiles
+  labels:
+    {{- include "zaakbrug.labels" . | nindent 4 }}
+data:
+  Profiles.json: {{ .Values.zaakbrug.globals | toJson | quote }}
+{{- end }}

--- a/charts/zaakbrug/templates/deployment.yaml
+++ b/charts/zaakbrug/templates/deployment.yaml
@@ -47,17 +47,17 @@ spec:
               mountPath: /usr/local/tomcat/conf/Catalina/localhost/ROOT.xml
               subPath: context.xml
               readOnly: true
-            {{- if .Values.zaakbrug.globalsConfigMap.name }}
-            - name: {{ template "zaakbrug.fullname" . }}-profiles-json
+            {{- if .Values.zaakbrug.globals }}
+            - name: {{ template "zaakbrug.fullname" . }}-globals
               mountPath: /opt/frank/configurations/Translate/Globals.json
+              subPath: Globals.json
               readOnly: true
-              subPath: {{ .Values.zaakbrug.profilesConfigMap.subPath }}
             {{- end }}
-            {{- if .Values.zaakbrug.profilesConfigMap.name }}
-            - name: {{ template "zaakbrug.fullname" . }}-profiles-json
+            {{- if .Values.zaakbrug.profiles }}
+            - name: {{ template "zaakbrug.fullname" . }}-profiles
               mountPath: /opt/frank/configurations/Translate/Profiles.json
+              subPath: Profiles.json
               readOnly: true
-              subPath: {{ .Values.zaakbrug.profilesConfigMap.subPath }}
             {{- end }}
             {{- if .Values.frank.credentials.secret }}
             - name: {{ template "zaakbrug.fullname" . }}-credentials
@@ -87,15 +87,15 @@ spec:
         - name: {{ template "zaakbrug.fullname" . }}-specifics
           configMap:
             name: {{ template "zaakbrug.fullname" . }}-specifics
-        {{- if .Values.zaakbrug.globalsConfigMap.name }}
-        - name: {{ template "zaakbrug.fullname" . }}-globals-json
+        {{- if .Values.zaakbrug.globals }}
+        - name: {{ template "zaakbrug.fullname" . }}-globals
           configMap:
-            name: {{ .Values.zaakbrug.globalsConfigMap.name }}
+            name: {{ template "zaakbrug.fullname" . }}-globals
         {{- end }}
-        {{- if .Values.zaakbrug.profilesConfigMap.name }}
-        - name: {{ template "zaakbrug.fullname" . }}-profiles-json
+        {{- if .Values.zaakbrug.profiles }}
+        - name: {{ template "zaakbrug.fullname" . }}-profiles
           configMap:
-            name: {{ .Values.zaakbrug.globalsConfigMap.name }}
+            name: {{ template "zaakbrug.fullname" . }}-profiles
         {{- end }}
         {{- if .Values.frank.credentials.secret }}
         - name: {{ template "zaakbrug.fullname" . }}-credentials

--- a/charts/zaakbrug/values.yaml
+++ b/charts/zaakbrug/values.yaml
@@ -111,12 +111,29 @@ zaakbrug:
       informatieobjecttype: "catalogi/api/v1/informatieobjecttypen"
       enkelvoudiginformatieobjecten: "documenten/api/v1/enkelvoudiginformatieobjecten"
       zaakinformatieobjecten: "zaken/api/v1/zaakinformatieobjecten"
-  globalsConfigMap:
-    name: ""
-    key: ""
-  profilesConfigMap:
-    name: ""
-    key: ""
+  globals:
+    organizations:
+      - gemeenteNaam: "Utrecht"
+        gemeenteCode: "0344"
+        RSIN: "002220647"
+    rolMapping:
+      heeftBetrekkingOp: "BetrekkingOp"
+      heeftAlsBelanghebbende: "Belanghebbende"
+      heeftAlsInitiator: "Initiator"
+      heeftAlsUitvoerende: "Uitvoerende"
+      heeftAlsVerantwoordelijke: "Verantwoordelijke"
+      heeftAlsGemachtigde: "Gemachtigde"
+      heeftAlsOverigBetrokkene: "OverigeBetrokkene"
+  profiles:
+    profile:
+      - zaakTypeIdentificatie: "B9999"
+        endCaseEndDate:
+          coalesceResultaat: "Onbekend"
+        endDateAndResultLastStatus:
+          coalesceResultaat: "Onbekend"
+      - zaakTypeIdentificatie: "B1026"
+        endCaseEndDate:
+          coalesceResultaat: "Toegekend"
 
 frank:
   # Secret containing the contents of the credentials.properties


### PR DESCRIPTION
No need for the user to add thier own config map to the cluster, they can just fill in the data in the values and the json files will be created automatically. 

Closes #23 

---

I would want some subjective advice, please.

Would it be logical to:
not include the files (and thus not overwriting) if no data is entered?
\- Or - 
overwrite the files with empty ones if no data is given, indicating that the user should enter their values?
\- Or - 
include default globals and profiles in the values, and overwrite the files in the image? (could also combine with the first option)