### PR TITLE
fix(docker): :wrench: Mount default database subfolder in docker-compose by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ FrankConfig.xsd
 Test.properties
 /.idea/
 /target/
+/data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,8 @@ services:
     build: .
     image: zaakbrug
     container_name: zaakbrug
+    volumes:
+      - ./data:/usr/local/tomcat/data
     environment:
       - zgw.baseurl=http://open-zaak:8000/
     ports:


### PR DESCRIPTION
Fixes #26 