### PR TITLE
fix: authorization token missing for GetZaakDocumentByUrl

### DIFF
--- a/src/main/configurations/Translate/Configuration_GetZaakDocumentByUrl.xml
+++ b/src/main/configurations/Translate/Configuration_GetZaakDocumentByUrl.xml
@@ -23,7 +23,7 @@
 				/>
                 <Param name="url" sessionKey="Url"/>
                 <Param name="Accept-Crs" value="EPSG:4326"/>
-                <Param name="Authorization" value="Bearer @@documenten-api.jwt@@ "/>
+                <Param name="Authorization" value="Bearer @@documenten-api.jwt@@"/>
                 <Forward name="success" path="JsonToXml" />
                 <Forward name="exception" path="ErrorJsonToXml" />
 			</SenderPipe>


### PR DESCRIPTION
Authorization value wasn't correctly set