### PR TITLE
refactor: implement zds 1.2 genereerBesluitIdentificatie_Di02 SOAP-action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 [![conventional commits](https://img.shields.io/badge/conventional%20commits-1.0.0-yellow.svg)](https://conventionalcommits.org) [![semantic versioning](https://img.shields.io/badge/semantic%20versioning-2.0.0-green.svg)](https://semver.org)
 
+## [1.12.27](https://github.com/ibissource/zaakbrug/compare/v1.12.26...v1.12.27) (2023-07-12)
+
+
+### 🐛 Bug Fixes
+
+* docker-compose network name correction due to changes in latest docker-compose version ([#131](https://github.com/ibissource/zaakbrug/issues/131)) ([a9806a2](https://github.com/ibissource/zaakbrug/commit/a9806a26c954017988ef0737d80207db1e6bdec0))
+
 ## [1.12.26](https://github.com/ibissource/zaakbrug/compare/v1.12.25...v1.12.26) (2023-07-04)
 
 

--- a/charts/zaakbrug/Chart.yaml
+++ b/charts/zaakbrug/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: 1.12.26
+appVersion: 1.12.27
 description: Install ZaakBrug (zds-to-zgw) on Haven, powered by the Frank!Framework
 name: zaakbrug
 type: application
-version: 1.12.26
+version: 1.12.27
 home: https://github.com/ibissource/zaakbrug
 icon: https://raw.githubusercontent.com/ibissource/zaakbrug/master/zaakbrug-icon.png
 keywords:

--- a/charts/zaakbrug/templates/configmap.yaml
+++ b/charts/zaakbrug/templates/configmap.yaml
@@ -59,11 +59,15 @@ data:
   zaakbrug.soap.vrije-berichten.endpoint: {{ .endpoint }}
   zaakbrug.soap.vrije-berichten.validation-soft-fail: "{{ .validationSoftFail }}"
   {{- end }}
+  {{- with .vrijeBerichten_v2 }}
+  zaakbrug.soap.vrije-berichten.v2.endpoint: {{ .endpoint }}
+  zaakbrug.soap.vrije-berichten.v2.validation-soft-fail: "{{ .validationSoftFail }}"
+  {{- end }}
   {{- end }}
   {{- with .Values.zaakbrug.zgw }}
   zaakbrug.zgw.zaak-identificatie-template: {{ .zaakIdentificatieTemplate }}
   zaakbrug.zgw.document-identificatie-template: {{ .documentIdentificatieTemplate }}
-  zaakbrug.zgw.document-besluit-template: {{ .besluitIdentificatieTemplate }}
+  zaakbrug.zgw.besluit-identificatie-template: {{ .besluitIdentificatieTemplate }}
   {{- with .zakenApi }}
   zaakbrug.zgw.zaken-api.root-url: {{ .rootUrl }}
   zaakbrug.zgw.zaken-api.timeout: {{ toString (.timeout | default 20000 | quote) }}

--- a/charts/zaakbrug/values.yaml
+++ b/charts/zaakbrug/values.yaml
@@ -104,7 +104,7 @@ zaakbrug:
     vrijeBerichten:
       endpoint: "translate/generic/zds/VrijBericht"
       validationSoftFail: false
-    vrijeBerichtenV2:
+    vrijeBerichten_v2:
       endpoint: "translate/generic/zds/v2/VrijBericht"
       validationSoftFail: false
   zgw:

--- a/docker-compose.openforms.dev.yml
+++ b/docker-compose.openforms.dev.yml
@@ -89,7 +89,7 @@ services:
     depends_on:
       - open-forms
     networks:
-      - open-forms
+      - zaakbrug-stack
       - open-forms-backend
   nginx:
     image: nginx
@@ -144,7 +144,6 @@ volumes:
   open-forms-data:
 
 networks:
-  open-forms:
-    name: zaakbrug-stack
+  zaakbrug-stack:
   open-forms-backend:
   

--- a/docker-compose.openzaak.dev.yml
+++ b/docker-compose.openzaak.dev.yml
@@ -89,7 +89,7 @@ services:
       - ./docker/open-zaak-nginx/default.conf:/etc/nginx/conf.d/default.conf
       - open-zaak-private-media:/private-media
     networks:
-      - open-zaak
+      - zaakbrug-stack
       - open-zaak-backend
     ports:
       - 9001:9001
@@ -119,6 +119,5 @@ volumes:
   open-zaak-private-media:
 
 networks:
-  open-zaak:
-    name: zaakbrug-stack
+  zaakbrug-stack:
   open-zaak-backend:

--- a/docker-compose.zaakbrug.dev.yml
+++ b/docker-compose.zaakbrug.dev.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - ./docker/zaakbrug-nginx/default.conf:/etc/nginx/conf.d/default.conf
     networks:
-      - zaakbrug
+      - zaakbrug-stack
       - zaakbrug-backend
     ports:
       - 9000:9000
@@ -26,7 +26,7 @@ services:
       # - ./data:/usr/local/tomcat/data
       - ./src/main/configurations:/opt/frank/configurations:ro
     networks:
-      - zaakbrug
+      - zaakbrug-stack
       - zaakbrug-backend
     ports:
       - 8080:8080
@@ -38,6 +38,5 @@ volumes:
   private-media:
 
 networks:
-  zaakbrug:
-    name: zaakbrug-stack
+  zaakbrug-stack:
   zaakbrug-backend:

--- a/docker-compose.zaakbrug.staging.dev.yml
+++ b/docker-compose.zaakbrug.staging.dev.yml
@@ -119,6 +119,5 @@ volumes:
   zaakbrug-staging-private-media:
 
 networks:
-  zaakbrug:
-    name: zaakbrug-stack
+  zaakbrug-stack:
   zaakbrug-backend:

--- a/src/main/configurations/Translate/Configuration_SoapEndpointRouter_VrijeBerichten_v2.xml
+++ b/src/main/configurations/Translate/Configuration_SoapEndpointRouter_VrijeBerichten_v2.xml
@@ -2,7 +2,6 @@
     <Adapter name="SoapEndpointRouter_VrijeBerichten_v2"
         active="${SoapEndpointRouter_VrijeBerichten_v2.Active}"
         description="">
-
         <Receiver name="SoapEndpointRouter_VrijeBerichten_v2">
             <WebServiceListener name="SoapEndpointRouter_VrijeBerichten_v2" address="${zaakbrug.soap.vrije-berichten.v2.endpoint}" soap="false"/>
             <JdbcErrorStorage
@@ -10,68 +9,43 @@
                 datasourceName="jdbc/${database.instance.name}"
                 slotId="${instance.name}/vrijeBerichten_v2"/>
         </Receiver>
-
         <Pipeline>
             <Exits>
                 <Exit name="EXIT" state="SUCCESS"/>
                 <Exit name="EXCEPTION" state="ERROR"/>
             </Exits>
 
-            <XsltPipe
-                name="RemoveComments"
-                styleSheetName="Common/xsl/RemoveComments.xslt"
-                storeResultInSessionKey="SanitizedMessage"
-                >
-                <Forward name="success" path="SanitizeSoapAction"/>
-                <Forward name="error" path="EXCEPTION"/>
-            </XsltPipe>
-
-            <XsltPipe
-                name="SanitizeSoapAction"
-                xpathExpression="replace($Action, '/', '_')"
-                storeResultInSessionKey="SatitizedSoapAction"
-                >
-                <Param name="Action" sessionKey="SOAPAction"/>
-                <Forward name="success" path="ActionSwitch"/>
-                <Forward name="error" path="EXCEPTION"/>
-            </XsltPipe>
-
-            <XmlSwitchPipe name="ActionSwitch"
-				forwardNameSessionKey="SatitizedSoapAction"
-                />
-
-            <!-- GenereerBesluitIdentificatie_Di02 -->
             <WsdlXmlValidatorPipe 
-                name="http:__www.stufstandaarden.nl_koppelvlak_zds0120_genereerBesluitIdentificatie_Di02"
-                getInputFromSessionKey="SanitizedMessage"
+                name="ValidateInput"
                 wsdl="Common/xsd/Zaak-_Documentservices_1_2/zds0120/berichten/zds0120_vrijeBerichten_zs-dms.wsdl"
-                
-                soapBody="genereerBesluitIdentificatie_Di02"
                 >
-                <Forward name="success" path="UnwrapMessageForGenereerBesluitIdentificatie_Di02"/>
-                <Forward name="failure" path="WsdlValidationSoftFailForwarder_GenereerBesluitIdentificatie"/>
+                <Forward name="success" path="UnwrapSoapMessage"/>
+                <Forward name="failure" path="WsdlValidationSoftFailForwarder"/>
             </WsdlXmlValidatorPipe>
 
             <XmlSwitchPipe 
-                name="WsdlValidationSoftFailForwarder_GenereerBesluitIdentificatie"
+                name="WsdlValidationSoftFailForwarder"
                 xpathExpression="$SoftFail = true()"
                 >
                 <Param name="SoftFail" value="${zaakbrug.soap.vrije-berichten.v2.validation-soft-fail}" type="BOOLEAN"/>
-                <Forward name="true" path="UnwrapMessageForGenereerBesluitIdentificatie_Di02" />
+                <Forward name="true" path="UnwrapSoapMessage" />
                 <Forward name="false" path="InvalidXml" />
             </XmlSwitchPipe>
 
             <SoapWrapperPipe 
-                name="UnwrapMessageForGenereerBesluitIdentificatie_Di02"
+                name="UnwrapSoapMessage"
                 storeResultInSessionKey="UnwrapMessageResult"
                 direction="UNWRAP"
                 removeOutputNamespaces="true">
                 <Forward name="success" path="GenereerBesluitIdentificatie_Di02Sender"/>
             </SoapWrapperPipe>
-
+            
             <SenderPipe
                 name="GenereerBesluitIdentificatie_Di02Sender"
-                storeResultInSessionKey="Identificatie">
+                storeResultInSessionKey="Identificatie"
+                onlyIfSessionKey="SOAPAction"
+                onlyIfValue="http://www.stufstandaarden.nl/koppelvlak/zds0120/genereerBesluitIdentificatie_Di02"
+                >
                 <IbisLocalSender
                     name="GenereerBesluitIdentificatie_Di02LocalSender"
                     javaListener="GenereerIdentificatieEmulator"
@@ -81,6 +55,10 @@
                 <Forward name="success" path="WrapGenereerBesluitIdentificatie_Du02Response" />
                 <Forward name="exception" path="BackEndError" />
             </SenderPipe>
+            
+            <!-- Intentional fallthrough -->
+            
+            <!-- Undefined SOAP action error handling. Needed to catch the fallthrough incase no mathing action-->
 
             <SoapWrapperPipe
                 name="WrapGenereerBesluitIdentificatie_Du02Response"
@@ -93,19 +71,16 @@
             </SoapWrapperPipe>
 
             <!-- ERRORS -->
-
             <PutInSessionPipe name="InvalidXml">
                 <Param name="errorCode" value="INVALID_XML"/>
                 <Param name="errorReason" value="XML was invalid"/>
                 <Forward name="success" path="WrapFo03Response" />
             </PutInSessionPipe>
-
             <PutInSessionPipe name="NotWellFormed">
                 <Param name="errorCode" value="NOT_WELL_FORMED_XML"/>
                 <Param name="errorReason" value="XML was not according to xsd"/>                
                 <Forward name="success" path="WrapFo03Response"/>
             </PutInSessionPipe>
-
             <PutInSessionPipe name="BackEndError" unlessSessionKey="errorCode">
                 <Param name="errorCode" styleSheetName="Common/xsl/BackEndError.xsl"/>
                 <Param name="errorReason" xpathExpression="/error/reason"/>

--- a/src/main/configurations/Translate/Configuration_SoapEndpointRouter_VrijeBerichten_v2.xml
+++ b/src/main/configurations/Translate/Configuration_SoapEndpointRouter_VrijeBerichten_v2.xml
@@ -37,15 +37,27 @@
                 storeResultInSessionKey="UnwrapMessageResult"
                 direction="UNWRAP"
                 removeOutputNamespaces="true">
-                <Forward name="success" path="GenereerBesluitIdentificatie_Di02Sender"/>
+                <Forward name="success" path="SanitizeSoapAction"/>
             </SoapWrapperPipe>
+
+            <XsltPipe
+                name="SanitizeSoapAction"
+                xpathExpression="replace($Action, '/', '_')"
+                storeResultInSessionKey="SanitizedSoapAction"
+                preserveInput="true"
+                >
+                <Param name="Action" sessionKey="SOAPAction"/>
+                <Forward name="success" path="ActionSwitch"/>
+                <Forward name="error" path="EXCEPTION"/>
+            </XsltPipe>
+
+            <XmlSwitchPipe name="ActionSwitch"
+				forwardNameSessionKey="SanitizedSoapAction"
+                />
             
             <SenderPipe
-                name="GenereerBesluitIdentificatie_Di02Sender"
-                storeResultInSessionKey="Identificatie"
-                onlyIfSessionKey="SOAPAction"
-                onlyIfValue="http://www.stufstandaarden.nl/koppelvlak/zds0120/genereerBesluitIdentificatie_Di02"
-                >
+                name="http:__www.stufstandaarden.nl_koppelvlak_zds0120_genereerBesluitIdentificatie_Di02"
+                storeResultInSessionKey="Identificatie">
                 <IbisLocalSender
                     name="GenereerBesluitIdentificatie_Di02LocalSender"
                     javaListener="GenereerIdentificatieEmulator"
@@ -60,6 +72,7 @@
             
             <!-- Undefined SOAP action error handling. Needed to catch the fallthrough incase no mathing action-->
 
+        
             <SoapWrapperPipe
                 name="WrapGenereerBesluitIdentificatie_Du02Response"
                 getInputFromSessionKey="UnwrapMessageResult"
@@ -69,6 +82,7 @@
                 <Param name="Identificatie" sessionKey="Identificatie" type="STRING" />
                 <Forward name="success" path="EXIT"/>
             </SoapWrapperPipe>
+
 
             <!-- ERRORS -->
             <PutInSessionPipe name="InvalidXml">

--- a/src/main/configurations/Translate/Configuration_SoapEndpointRouter_VrijeBerichten_v2.xml
+++ b/src/main/configurations/Translate/Configuration_SoapEndpointRouter_VrijeBerichten_v2.xml
@@ -67,11 +67,7 @@
                 <Forward name="success" path="WrapGenereerBesluitIdentificatie_Du02Response" />
                 <Forward name="exception" path="BackEndError" />
             </SenderPipe>
-            
-            <!-- Intentional fallthrough -->
-            
-            <!-- Undefined SOAP action error handling. Needed to catch the fallthrough incase no mathing action-->
-
+        
         
             <SoapWrapperPipe
                 name="WrapGenereerBesluitIdentificatie_Du02Response"


### PR DESCRIPTION
- Even though the branch name implies the main epic ticket name (GT-676_Besluiten_API), this branch only implemented the "genereerBesluitIdentificatie_Di02" SOAP-action.
- We have decided to merge it to master before finishing other adapters created with the new template to be able to keep the continuous integration.