### PR TITLE
fix: identificatie generation producing duplicates during highly-concurrent workload

### DIFF
--- a/src/main/configurations/Translate/Configuration_GenereerIdentificatieEmulator.xml
+++ b/src/main/configurations/Translate/Configuration_GenereerIdentificatieEmulator.xml
@@ -11,7 +11,7 @@
                 slotId="${instance.name}/genereerIdentificatieEmulator"/>
         </Receiver>
 
-        <Pipeline>
+        <Pipeline transactionAttribute="RequiresNew">
             <Exits>
                 <Exit name="EXIT" state="SUCCESS"/>
                 <Exit name="EXCEPTION" state="ERROR"/>
@@ -22,7 +22,8 @@
                 <FixedQuerySender 
                     query="SELECT IDENTIFICATIE FROM IDENTIFICATIE WHERE TYPE  = ?{IdentificatieType}" 
                     queryType="SELECT" 
-                    />
+                    lockWait="10"
+                    lockRows="true"/>
                     <Param name="IdentificatieType" sessionKey="IdentificatieType"/>
                 <Forward name="success" path="CheckForDBResult" />
             </SenderPipe>

--- a/src/main/configurations/Translate/Configuration_GenereerIdentificatieEmulator.xml
+++ b/src/main/configurations/Translate/Configuration_GenereerIdentificatieEmulator.xml
@@ -3,7 +3,7 @@
         active="${GenereerIdentificatieEmulator.Active}"
         description="">
 
-        <Receiver name="GenereerIdentificatieEmulator">
+        <Receiver name="GenereerIdentificatieEmulator" transactionAttribute="Required">
             <JavaListener name="GenereerIdentificatieEmulator"/>
             <JdbcErrorStorage
                 name="JdbcErrorStorage"
@@ -11,7 +11,7 @@
                 slotId="${instance.name}/genereerIdentificatieEmulator"/>
         </Receiver>
 
-        <Pipeline transactionAttribute="RequiresNew">
+        <Pipeline>
             <Exits>
                 <Exit name="EXIT" state="SUCCESS"/>
                 <Exit name="EXCEPTION" state="ERROR"/>


### PR DESCRIPTION
Apparent simple fix for the errors which arrive when multiple calls are made at the same time.