### PR TITLE
Error Message not returned to CLO

### DIFF
--- a/src/main/configurations/Translate/Configuration_SetResultaatAndStatus.xml
+++ b/src/main/configurations/Translate/Configuration_SetResultaatAndStatus.xml
@@ -366,8 +366,7 @@
 
             <ForEachChildElementPipe name="PostStatusIterator"
                 getInputFromSessionKey="NewStatuses"
-                elementXPathExpression="ZgwStatussen/ZgwStatus"
-                parallel="true">
+                elementXPathExpression="ZgwStatussen/ZgwStatus">
                 <IbisLocalSender
                     name="PostZgwStatusLocalSender"
                     javaListener="Zaken_PostZgwStatus">


### PR DESCRIPTION
parallel="true" attribute is removed from "SetResultaatAndStatus.xml adapter and the tests have been run and they are still passing.