### PR TITLE
fix: Fix for the problem Error message not returned to CLO

### DIFF
--- a/src/main/configurations/Translate/Configuration_SetResultaatAndStatus.xml
+++ b/src/main/configurations/Translate/Configuration_SetResultaatAndStatus.xml
@@ -364,10 +364,10 @@
                 <Forward name="success" path="PostStatusIterator"/>
             </XsltPipe>
 
+            <!-- https://github.com/ibissource/zaakbrug/issues/144 -->
             <ForEachChildElementPipe name="PostStatusIterator"
                 getInputFromSessionKey="NewStatuses"
-                elementXPathExpression="ZgwStatussen/ZgwStatus"
-                parallel="true">
+                elementXPathExpression="ZgwStatussen/ZgwStatus">
                 <IbisLocalSender
                     name="PostZgwStatusLocalSender"
                     javaListener="Zaken_PostZgwStatus">


### PR DESCRIPTION
The attribute parallel:"true" is removed from "ForEachChildElementPipe" in the SetResultaatAndStatus.xml adapter. The tests have been run again after the fix and they were passing fine.