### PR TITLE
fix: Error message not returned to CLO in ForEachChildElementPipe in GeefLijstZaakdocumenten adapter

### DIFF
--- a/src/main/configurations/Translate/Configuration_GeefLijstZaakdocumenten_Lv01.xml
+++ b/src/main/configurations/Translate/Configuration_GeefLijstZaakdocumenten_Lv01.xml
@@ -42,8 +42,7 @@
             </SenderPipe>
 
             <ForEachChildElementPipe name="ZgwZaakInformatieObjectenIterator"
-                elementXPathExpression="/ZgwZaakInformatieObjecten/ZgwZaakInformatieObject"
-                parallel="true">
+                elementXPathExpression="/ZgwZaakInformatieObjecten/ZgwZaakInformatieObject">
                 <IbisLocalSender
                     name="CallHandleZgwZaakInformatieObjecten"
                     javaListener="HandleZgwZaakInformatieObjecten">

--- a/src/main/configurations/Translate/Configuration_GeefLijstZaakdocumenten_Lv01.xml
+++ b/src/main/configurations/Translate/Configuration_GeefLijstZaakdocumenten_Lv01.xml
@@ -41,6 +41,7 @@
                 <Forward name="exception" path="EXCEPTION" />
             </SenderPipe>
 
+            <!-- https://github.com/ibissource/zaakbrug/issues/149 -->
             <ForEachChildElementPipe name="ZgwZaakInformatieObjectenIterator"
                 elementXPathExpression="/ZgwZaakInformatieObjecten/ZgwZaakInformatieObject">
                 <IbisLocalSender


### PR DESCRIPTION
The attribute parallel:"true" is removed from "ForEachChildElementPipe" in the GeefLijstZaakdocumenten.xml adapter. The tests have been run again after the fix and they were passing fine.